### PR TITLE
[FIX]: Disable leakless to avoid windows defender panic

### DIFF
--- a/internal/scraper/analyzer.go
+++ b/internal/scraper/analyzer.go
@@ -44,7 +44,7 @@ func New() (*RodAnalyzer, error) {
 		l = launcher.New().Bin(path)
 	}
 
-	u := l.Headless(true).NoSandbox(true).MustLaunch()
+	u := l.Headless(true).NoSandbox(true).Leakless(false).MustLaunch()
 	browser := rod.New().ControlURL(u).MustConnect()
 
 	router := browser.HijackRequests()

--- a/tests/integration/analyzer_test.go
+++ b/tests/integration/analyzer_test.go
@@ -21,7 +21,7 @@ type MockAnalyzer struct {
 
 // New creates a new MockAnalyzer
 func NewMockAnalyzer() (*MockAnalyzer, error) {
-	u := launcher.New().Headless(true).NoSandbox(true).MustLaunch()
+	u := launcher.New().Headless(true).Leakless(false).NoSandbox(true).MustLaunch()
 	browser := rod.New().ControlURL(u).MustConnect()
 
 	return &MockAnalyzer{


### PR DESCRIPTION
## Summary by Sourcery

Disable leakless mode in the browser launcher and its mock tests to prevent Windows Defender from flagging the process

Bug Fixes:
- Disable leakless mode in the browser launcher to prevent Windows Defender panic

Tests:
- Disable leakless mode in the MockAnalyzer integration test to align with the production fix