### PR TITLE
[FEAT]: Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 *.dll
 *.so
 *.dylib
-
+.idea
+.air
 # Test binary, built with `go test -c`
 *.test
 

--- a/api/api.go
+++ b/api/api.go
@@ -1,10 +1,18 @@
 package api
 
 import (
+	"github.com/gin-contrib/cache"
+	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"scraper/handlers"
+	"time"
 )
 
 func AddMetricsRoutes(group *gin.RouterGroup) {
 	group.GET("/system/metrics", gin.WrapH(promhttp.Handler()))
+}
+
+func AddAnalyzeRoutes(group *gin.RouterGroup, store persistence.CacheStore, ttl time.Duration, controller *handlers.AnalysisController) {
+	group.GET("/analyze/", cache.CachePage(store, ttl, controller.Analyze))
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -24,21 +24,19 @@ func NewServer(analysisController *handlers.AnalysisController) *http.Server {
 	router.Use(middleware.LeakBucket())
 	router.Use(gin.Recovery())
 
-	store := persistence.NewInMemoryStore(10 * time.Minute)
+	store := persistence.NewInMemoryStore(config.Config.InMemStoreTTL * time.Minute)
 
 	api := router.Group("/api")
 	v1 := api.Group("/v1")
 	{
-		v1.GET("/analyze/", cache.CachePage(store, 5*time.Minute, analysisController.Analyze))
+		v1.GET("/analyze/", cache.CachePage(store, config.Config.InMemStoreTTL*time.Minute, analysisController.Analyze))
 		api2.AddMetricsRoutes(v1)
 	}
 
 	server := &http.Server{
-		Addr:         config.Config.Host + ":" + config.Config.Port,
-		Handler:      router,
-		ReadTimeout:  1 * time.Minute,
-		WriteTimeout: 1 * time.Minute,
-		IdleTimeout:  1 * time.Minute,
+		Addr:    config.Config.Host + ":" + config.Config.Port,
+		Handler: router,
 	}
+
 	return server
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,21 +1,14 @@
 package cmd
 
 import (
-	"github.com/gin-contrib/cache"
-	"github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
-	"net/http"
-	api2 "scraper/api"
 	"scraper/common"
-	"scraper/config"
-	"scraper/handlers"
 	"scraper/middleware"
-	"time"
 )
 
-// NewServer creates a new HTTP server with the configured routes and middleware.
-func NewServer(analysisController *handlers.AnalysisController) *http.Server {
+// NewRouter initializes the Gin router with all necessary middleware and routes.
+func NewRouter() *gin.Engine {
 	router := gin.Default()
 
 	router.Use(otelgin.Middleware(common.ServiceName))
@@ -24,19 +17,5 @@ func NewServer(analysisController *handlers.AnalysisController) *http.Server {
 	router.Use(middleware.LeakBucket())
 	router.Use(gin.Recovery())
 
-	store := persistence.NewInMemoryStore(config.Config.InMemStoreTTL * time.Minute)
-
-	api := router.Group("/api")
-	v1 := api.Group("/v1")
-	{
-		v1.GET("/analyze/", cache.CachePage(store, config.Config.InMemStoreTTL*time.Minute, analysisController.Analyze))
-		api2.AddMetricsRoutes(v1)
-	}
-
-	server := &http.Server{
-		Addr:    config.Config.Host + ":" + config.Config.Port,
-		Handler: router,
-	}
-
-	return server
+	return router
 }

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Cfg struct {
 	Host           string        `mapstructure:"HOST"`
 	ChromeSetup    string        `mapstructure:"CHROME_SETUP"`
 	Leakless       bool          `mapstructure:"LEAKLESS"`
+	AnalyzerType   string        `mapstructure:"ANALYZER_TYPE"`
 	AnalyzeTimeOut time.Duration `mapstructure:"ANALYZE_TIMEOUT"`
 	InMemStoreTTL  time.Duration `mapstructure:"IN_MEM_STORE_TTL"`
 	Headless       bool          `mapstructure:"HEADLESS"`
@@ -26,6 +27,7 @@ func setDefaults() {
 	viper.SetDefault("PORT", "8080")
 	viper.SetDefault("HOST", "0.0.0.0")
 	viper.SetDefault("LEAKLESS", true)
+	viper.SetDefault("ANALYZER_TYPE", "rod")
 	viper.SetDefault("ANALYZE_TIMEOUT", 2)
 	viper.SetDefault("IN_MEM_STORE_TTL", 5)
 	viper.SetDefault("HEADLESS", true)
@@ -66,6 +68,7 @@ func bindEnvVariables() {
 	_ = viper.BindEnv("HOST")
 	_ = viper.BindEnv("CHROME_SETUP")
 	_ = viper.BindEnv("LEAKLESS")
+	_ = viper.BindEnv("ANALYZER_TYPE")
 	_ = viper.BindEnv("ANALYZE_TIMEOUT")
 	_ = viper.BindEnv("IN_MEM_STORE_TTL")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -71,4 +71,5 @@ func bindEnvVariables() {
 	_ = viper.BindEnv("ANALYZER_TYPE")
 	_ = viper.BindEnv("ANALYZE_TIMEOUT")
 	_ = viper.BindEnv("IN_MEM_STORE_TTL")
+	_ = viper.BindEnv("HEADLESS")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"github.com/go-playground/validator/v10"
 	"github.com/spf13/viper"
+	"path/filepath"
+	"runtime"
 	"scraper/internal/logger"
+	"time"
 )
 
 type Cfg struct {
-	Port        string `mapstructure:"PORT"`
-	Host        string `mapstructure:"HOST"`
-	ChromeSetup string `mapstructure:"CHROME_SETUP"`
-	Leakless    bool   `mapstructure:"LEAKLESS"`
+	Port           string        `mapstructure:"PORT"`
+	Host           string        `mapstructure:"HOST"`
+	ChromeSetup    string        `mapstructure:"CHROME_SETUP"`
+	Leakless       bool          `mapstructure:"LEAKLESS"`
+	AnalyzeTimeOut time.Duration `mapstructure:"ANALYZE_TIMEOUT"`
+	InMemStoreTTL  time.Duration `mapstructure:"IN_MEM_STORE_TTL"`
+	Headless       bool          `mapstructure:"HEADLESS"`
 }
 
 var Config *Cfg
@@ -20,6 +26,9 @@ func setDefaults() {
 	viper.SetDefault("PORT", "8080")
 	viper.SetDefault("HOST", "0.0.0.0")
 	viper.SetDefault("LEAKLESS", true)
+	viper.SetDefault("ANALYZE_TIMEOUT", 2)
+	viper.SetDefault("IN_MEM_STORE_TTL", 5)
+	viper.SetDefault("HEADLESS", true)
 }
 
 func GetConfig() *Cfg {
@@ -32,6 +41,10 @@ func GetConfig() *Cfg {
 
 	viper.SetConfigName(".env")
 	viper.SetConfigType("env")
+
+	_, b, _, _ := runtime.Caller(0)
+	viper.AddConfigPath(filepath.Dir(b) + "/..")
+
 	_ = viper.ReadInConfig()
 
 	Config = &Cfg{}
@@ -53,4 +66,6 @@ func bindEnvVariables() {
 	_ = viper.BindEnv("HOST")
 	_ = viper.BindEnv("CHROME_SETUP")
 	_ = viper.BindEnv("LEAKLESS")
+	_ = viper.BindEnv("ANALYZE_TIMEOUT")
+	_ = viper.BindEnv("IN_MEM_STORE_TTL")
 }

--- a/handlers/analyzer.go
+++ b/handlers/analyzer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"scraper/config"
 	"scraper/internal/logger"
 	"scraper/services"
 	"time"
@@ -36,13 +37,13 @@ func (ac *AnalysisController) Analyze(c *gin.Context) {
 
 	logger.InfoCtx(ctx, "Analyzing webpage", logger.Field{Key: "url", Value: url})
 
-	analysisCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	analysisCtx, cancel := context.WithTimeout(ctx, config.Config.AnalyzeTimeOut*time.Minute)
 	defer cancel()
 
 	result, err := ac.AnalysisService.AnalyseWebPage(analysisCtx, url)
 	if err != nil {
 		logger.ErrorCtx(ctx, "Analysis failed", logger.Field{Key: "url", Value: url}, logger.Field{Key: "error", Value: err})
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to analyze the webpage: %v", err)})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to analyze the webpage, URL might be invalid!")})
 		return
 	}
 	c.JSON(http.StatusOK, result)

--- a/internal/scraper/analyzer.go
+++ b/internal/scraper/analyzer.go
@@ -44,7 +44,7 @@ func New() (*RodAnalyzer, error) {
 		l = launcher.New().Bin(path)
 	}
 
-	u := l.Headless(true).NoSandbox(true).Leakless(false).Set("no-sandbox").Set("disable-gpu").MustLaunch()
+	u := l.Headless(config.Config.Headless).NoSandbox(true).Leakless(config.Config.Leakless).Set("no-sandbox").Set("disable-gpu").MustLaunch()
 	browser := rod.New().ControlURL(u).MustConnect()
 
 	router := browser.HijackRequests()

--- a/internal/scraper/htmlAnalyzer/analyzer.go
+++ b/internal/scraper/htmlAnalyzer/analyzer.go
@@ -1,0 +1,23 @@
+package htmlAnalyzer
+
+import (
+	"context"
+	"scraper/dto"
+	"scraper/internal/logger"
+)
+
+type HTMLParse struct {
+}
+
+func New() (*HTMLParse, error) {
+	return &HTMLParse{}, nil
+}
+
+func (r *HTMLParse) Analyze(ctx context.Context, targetUrl string) (dto.AnalyzeWebsiteRes, error) {
+	logger.InfoCtx(ctx, "Visiting page", logger.Field{Key: "url", Value: targetUrl})
+	return dto.AnalyzeWebsiteRes{}, nil
+}
+
+func (r *HTMLParse) Close() error {
+	return nil
+}

--- a/internal/scraper/pageAnalyzer.go
+++ b/internal/scraper/pageAnalyzer.go
@@ -1,0 +1,12 @@
+package scraper
+
+import (
+	"context"
+	"scraper/dto"
+)
+
+// PageAnalyzer defines the common interface for any web page analyzer.
+type PageAnalyzer interface {
+	Analyze(ctx context.Context, url string) (dto.AnalyzeWebsiteRes, error)
+	Close() error
+}

--- a/internal/scraper/rodAnalyzer/analyzer.go
+++ b/internal/scraper/rodAnalyzer/analyzer.go
@@ -6,8 +6,6 @@ import (
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/proto"
-	"io"
-	"net/http"
 	"net/url"
 	"scraper/common"
 	"scraper/config"
@@ -19,12 +17,6 @@ import (
 var (
 	ErrConnectionError = errors.New("failed to connect to the webpage")
 )
-
-// PageAnalyzer defines the interface for analyzing web pages.
-type PageAnalyzer interface {
-	Analyze(ctx context.Context, url string) (dto.AnalyzeWebsiteRes, error)
-	Close() error
-}
 
 // RodAnalyzer is the concrete implementation of PageAnalyzer using the rod library.
 type RodAnalyzer struct {
@@ -143,28 +135,4 @@ func (r *RodAnalyzer) Analyze(ctx context.Context, targetUrl string) (dto.Analyz
 // Close cleans up the browser instance.
 func (r *RodAnalyzer) Close() error {
 	return r.Browser.Close()
-}
-
-// isExternal is a helper function to check if a link is external.
-func isExternal(link string, base *url.URL) bool {
-	linkURL, err := url.Parse(link)
-	if err != nil {
-		return false // Or handle as an inaccessible link
-	}
-	return linkURL.IsAbs() && linkURL.Hostname() != "" && linkURL.Hostname() != base.Hostname()
-}
-
-func isLinkAccessible(link string) bool {
-	resp, err := http.Head(link)
-	if err != nil {
-		logger.InfoCtx(context.Background(), "Failed to check link accessibility", logger.Field{Key: "link", Value: link})
-		return false
-	}
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			logger.ErrorCtx(context.Background(), "Failed to close response body", logger.Field{Key: "error", Value: err})
-		}
-	}(resp.Body)
-	return true
 }

--- a/internal/scraper/rodAnalyzer/utils.go
+++ b/internal/scraper/rodAnalyzer/utils.go
@@ -1,7 +1,12 @@
 package rodAnalyzer
 
 import (
+	"context"
 	"github.com/go-rod/rod"
+	"io"
+	"net/http"
+	"net/url"
+	"scraper/internal/logger"
 	"strings"
 )
 
@@ -46,4 +51,28 @@ func (ep *ExtendedPage) HTMLVersion() string {
 		return "HTML5"
 	}
 	return "HTML4 or older"
+}
+
+// isExternal is a helper function to check if a link is external.
+func isExternal(link string, base *url.URL) bool {
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return false // Or handle as an inaccessible link
+	}
+	return linkURL.IsAbs() && linkURL.Hostname() != "" && linkURL.Hostname() != base.Hostname()
+}
+
+func isLinkAccessible(link string) bool {
+	resp, err := http.Head(link)
+	if err != nil {
+		logger.InfoCtx(context.Background(), "Failed to check link accessibility", logger.Field{Key: "link", Value: link})
+		return false
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			logger.ErrorCtx(context.Background(), "Failed to close response body", logger.Field{Key: "error", Value: err})
+		}
+	}(resp.Body)
+	return true
 }

--- a/services/analyzer.go
+++ b/services/analyzer.go
@@ -8,11 +8,11 @@ import (
 
 // WebAnalysisService contains the business logic for analyzing a webpage.
 type WebAnalysisService struct {
-	Analyzer rodAnalyzer.PageAnalyzer
+	Analyzer scraper.PageAnalyzer
 }
 
 // NewWebAnalysisService creates a new WebAnalysisService.
-func NewWebAnalysisService(analyzer rodAnalyzer.PageAnalyzer) *WebAnalysisService {
+func NewWebAnalysisService(analyzer scraper.PageAnalyzer) *WebAnalysisService {
 	return &WebAnalysisService{Analyzer: analyzer}
 }
 

--- a/tests/integration/analyzer_test.go
+++ b/tests/integration/analyzer_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"scraper/dto"
-	rodAnalyzer "scraper/internal/scraper"
+	"scraper/internal/scraper/rodAnalyzer"
 	"scraper/services"
 	"testing"
 


### PR DESCRIPTION
## Summary by Sourcery

Configure and refactor the application to support pluggable page analyzers (Rod or HTML), centralize API routing and caching, and enhance configurability for analyzer behavior and timeouts.

New Features:
- Support selecting between Rod and HTML page analyzers via configuration
- Add a basic HTML analyzer implementation

Enhancements:
- Introduce a PageAnalyzer interface and refactor services and controllers to use it
- Parameterize Rod analyzer launch settings (headless, leakless) from config
- Centralize routing setup in a Gin router with modular API route registration
- Enable in-memory caching for the analyze endpoint using gin-contrib/cache
- Expand configuration with analyzer type, analyze timeout, cache TTL, and headless flags

Tests:
- Fix integration test import path for the Rod analyzer