### PR TITLE
[FEAT]: Refactor error response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+install:
+	go install github.com/air-verse/air@v1.61.7
+	@echo "\033[0;32mAir installed successfully. Use 'make dev' to start the development server.\033[0m"
+	go mod tidy
+	@echo "\033[0;32mGo modules installed successfully!\033[0m"
 build:
 	go build -o ./bin/server ./src
 start:

--- a/common/consts.go
+++ b/common/consts.go
@@ -1,3 +1,8 @@
 package common
 
 var ServiceName = "scraper-service"
+
+var (
+	RequestFail    = "fail"
+	RequestSuccess = "success"
+)

--- a/common/errors.go
+++ b/common/errors.go
@@ -5,26 +5,20 @@ import (
 )
 
 type GinError struct {
-	Code    int
-	Message string
-	Detail  any `json:"detail"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Errors  any    `json:"errors"`
 }
 
-// NewGinError Creates a new GinError with the given status code, message and detail.
-func NewGinError(code int, message string, detail any) *GinError {
+// NewGinError Creates a new GinError with the given status, message and detail.
+func NewGinError(status string, message string, detail any) *GinError {
 	return &GinError{
-		Code:    code,
+		Status:  status,
 		Message: message,
-		Detail:  detail,
+		Errors:  detail,
 	}
 }
 
-// Error implements the error interface for GinError. Do not rename this method.
 func (e *GinError) Error() string {
-	return fmt.Sprintf("%d: %s", e.Code, e.Message)
-}
-
-// Status returns the HTTP status code.
-func (e *GinError) Status() int {
-	return e.Code
+	return fmt.Sprintf("%d: %s", e.Status, e.Message)
 }

--- a/common/response.go
+++ b/common/response.go
@@ -1,0 +1,16 @@
+package common
+
+type GinResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}
+
+// NewGinResponse creates a new GinResponse with the given status, message, and detail.
+func NewGinResponse(status int, message string, data any) *GinResponse {
+	return &GinResponse{
+		Status:  status,
+		Message: message,
+		Data:    data,
+	}
+}

--- a/handlers/analyzer.go
+++ b/handlers/analyzer.go
@@ -2,8 +2,8 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"scraper/common"
 	"scraper/config"
 	"scraper/internal/logger"
 	"scraper/services"
@@ -26,12 +26,13 @@ func NewAnalysisController(service *services.WebAnalysisService) *AnalysisContro
 
 func (ac *AnalysisController) Analyze(c *gin.Context) {
 	ctx := c.Request.Context()
-	logger.InfoCtx(ctx, "Received request to analyze a webpage")
+	logger.InfoCtx(ctx, "Received a request to analyze a webpage")
 
 	url := c.Query("url")
 	if url == "" {
-		logger.InfoCtx(ctx, "Missing URL in request")
-		c.JSON(http.StatusBadRequest, gin.H{"error": "URL is required"})
+		logger.InfoCtx(ctx, "Missing URL in the request")
+		urlError := common.NewGinError(common.RequestFail, "URL is required", nil)
+		c.JSON(http.StatusBadRequest, urlError)
 		return
 	}
 
@@ -43,7 +44,7 @@ func (ac *AnalysisController) Analyze(c *gin.Context) {
 	result, err := ac.AnalysisService.AnalyseWebPage(analysisCtx, url)
 	if err != nil {
 		logger.ErrorCtx(ctx, "Analysis failed", logger.Field{Key: "url", Value: url}, logger.Field{Key: "error", Value: err})
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to analyze the webpage, URL might be invalid!")})
+		c.JSON(http.StatusInternalServerError, err)
 		return
 	}
 	c.JSON(http.StatusOK, result)


### PR DESCRIPTION
## Summary by Sourcery

Unify API error and response handling by introducing standardized response types and status constants, refactor existing GinError usages across analyzers and handlers, and improve developer setup with a Makefile install target.

Enhancements:
- Refactor GinError to use a string status and errors field with an updated constructor and error formatting
- Introduce a standardized GinResponse type and factory for successful API responses
- Add RequestFail and RequestSuccess status constants to centralize response statuses
- Update analyzer and handler code to return standardized GinError responses instead of raw errors or JSON maps

Build:
- Add an install target to the Makefile to install the Air tool and tidy Go modules